### PR TITLE
Changed input for button read to 1 Khz

### DIFF
--- a/11-29-count_buttons.v
+++ b/11-29-count_buttons.v
@@ -20,7 +20,7 @@ module implement_count_up_and_display(
     wire button, clear;
     assign button = BTNL;
     assign clear = BTNR;
-    count_button_push gate2( CLK100MHZ, button, clear, sum[31:0]);
+    count_button_push gate2( CLK_1KHZ, button, clear, sum[31:0]);
     
     assign LED[7:0] = sum[7:0];
     assign LED[8] = CLK_1HZ;


### PR DESCRIPTION
Due to bounce on the button and the count increasing by many more than 1 when the button is pushed as seen during testing, a change of 1Khz might fix this issue from the current 100Mhz. Should still be fast enough to read the button push but hopefully will only increment count by 1 or at least less than seen now.